### PR TITLE
Explictly request coverage Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       interval: "weekly"
       day: "friday"
     groups:
+      coverage:
+        patterns:
+          - "coverage"
+
       # Group together build dependencies. This is everything but coverage.
       #
       # Dependabot doesn't let us differentiate between


### PR DESCRIPTION
We don't seem to have been be getting them, presumably because coverage
isn't in any group?
