### PR TITLE
Update Python build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
         cache: 'pip'
 
     - name: Install dependencies
@@ -42,7 +42,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9"]
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "pypy3.10"
 
     steps:
     - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,14 @@ The `coverage_pth package <https://pypi.org/project/coverage_pth/>`__ attempts t
 but the wheels it provides only work on Python 3.6.
 It also `appears unmaintained <https://github.com/dougn/coverage_pth/commits/master/>`__.
 
+Compatiblity Policy
+-------------------
+
+Any version of CPython `supported upstream <https://devguide.python.org/versions/>`_ and by Coverage.py is considered supported and should be tested in CI.
+Additionally, CI covers supported 3.x releases of `PyPy <https://pypy.org/>`_, subject to availability in GitHub Actions.
+
+coverage-p is tested against the current version of Coverage.py.
+The API coverage-p invokes has been stable for many years, so compatibility issues are not expected.
 
 Changelog
 ---------


### PR DESCRIPTION
Add python3.13 and pypy3.10.

Remove python3.8 and pypy3.9.

Also write out the compatibility policy.
